### PR TITLE
Ensure players start with pets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # GPT_Test2
+
+This repository contains an example Roblox pet inventory system. The code lives in the `RobloxPetExample` folder.
+
+By default, new players start with three pets already in their inventory.
+
+See `RobloxPetExample/README.md` for details on how to set up the scripts inside your game.

--- a/RobloxPetExample/PetDataModule.lua
+++ b/RobloxPetExample/PetDataModule.lua
@@ -1,0 +1,10 @@
+local PetDataModule = {}
+
+-- Table of all available pets
+PetDataModule.Pets = {
+    ["Cat"] = {Name = "Cat", Icon = "rbxassetid://1234"},
+    ["Dog"] = {Name = "Dog", Icon = "rbxassetid://5678"},
+    ["Fox"] = {Name = "Fox", Icon = "rbxassetid://91011"},
+}
+
+return PetDataModule

--- a/RobloxPetExample/PetInventoryModule.lua
+++ b/RobloxPetExample/PetInventoryModule.lua
@@ -1,0 +1,86 @@
+local PetInventoryModule = {}
+local DataStoreService = game:GetService("DataStoreService")
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local PetDataModule = require(ReplicatedStorage:WaitForChild("PetDataModule"))
+
+local DEFAULT_PETS = {}
+for petName in pairs(PetDataModule.Pets) do
+    if #DEFAULT_PETS >= 3 then break end
+    table.insert(DEFAULT_PETS, petName)
+end
+
+local inventoryStore = DataStoreService:GetDataStore("PetInventory")
+
+-- Player data cache
+local playerData = {}
+
+local function loadData(player)
+    local success, data = pcall(function()
+        return inventoryStore:GetAsync(player.UserId)
+    end)
+    if success and type(data) == "table" then
+        playerData[player.UserId] = data
+    else
+        playerData[player.UserId] = {
+            Inventory = table.clone(DEFAULT_PETS),
+            EquippedPet = nil,
+            Favorites = {}
+        }
+    end
+end
+
+local function saveData(player)
+    local data = playerData[player.UserId]
+    if not data then return end
+    pcall(function()
+        inventoryStore:SetAsync(player.UserId, data)
+    end)
+end
+
+function PetInventoryModule.AddPet(player, petName)
+    local data = playerData[player.UserId]
+    table.insert(data.Inventory, petName)
+end
+
+function PetInventoryModule.EquipPet(player, petName)
+    local data = playerData[player.UserId]
+    data.EquippedPet = petName
+end
+
+function PetInventoryModule.UnequipPet(player)
+    local data = playerData[player.UserId]
+    data.EquippedPet = nil
+end
+
+function PetInventoryModule.ToggleFavorite(player, petName)
+    local data = playerData[player.UserId]
+    if data.Favorites[petName] then
+        data.Favorites[petName] = nil
+    else
+        data.Favorites[petName] = true
+    end
+end
+
+-- Returns player data, creating default tables if needed.
+function PetInventoryModule.GetPlayerData(player)
+    local data = playerData[player.UserId]
+    if not data then
+        data = {
+            Inventory = table.clone(DEFAULT_PETS),
+            EquippedPet = nil,
+            Favorites = {}
+        }
+        playerData[player.UserId] = data
+    end
+    return data
+end
+
+Players.PlayerAdded:Connect(loadData)
+Players.PlayerRemoving:Connect(function(player)
+    saveData(player)
+    playerData[player.UserId] = nil
+end)
+
+return PetInventoryModule

--- a/RobloxPetExample/PetUIController.lua
+++ b/RobloxPetExample/PetUIController.lua
@@ -1,0 +1,66 @@
+-- PetUIController.lua
+-- Client-side script that creates inventory UI and binds buttons
+
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local eventsFolder = ReplicatedStorage:WaitForChild("PetEvents")
+local requestInventory = eventsFolder:WaitForChild("RequestInventory")
+local equipPet = eventsFolder:WaitForChild("EquipPet")
+local toggleFavorite = eventsFolder:WaitForChild("ToggleFavorite")
+
+local player = Players.LocalPlayer
+local playerGui = player:WaitForChild("PlayerGui")
+
+local inventoryGui = Instance.new("ScreenGui")
+inventoryGui.Name = "PetInventoryGui"
+inventoryGui.Parent = playerGui
+
+local inventoryFrame = Instance.new("Frame")
+inventoryFrame.Size = UDim2.new(0, 300, 0, 400)
+inventoryFrame.Position = UDim2.new(0.5, -150, 0.5, -200)
+inventoryFrame.BackgroundColor3 = Color3.fromRGB(50, 50, 50)
+inventoryFrame.Parent = inventoryGui
+
+local function refreshInventory()
+    for _, child in ipairs(inventoryFrame:GetChildren()) do
+        if child:IsA("TextButton") or child:IsA("TextLabel") then
+            child:Destroy()
+        end
+    end
+
+    local data = requestInventory:InvokeServer()
+    local yOffset = 0
+    for _, petName in ipairs(data.Inventory) do
+        local button = Instance.new("TextButton")
+        button.Size = UDim2.new(1, -10, 0, 30)
+        button.Position = UDim2.new(0, 5, 0, yOffset)
+        button.Text = petName
+        button.BackgroundColor3 = data.EquippedPet == petName and Color3.fromRGB(0,200,0) or Color3.fromRGB(100,100,100)
+        button.Parent = inventoryFrame
+
+        button.MouseButton1Click:Connect(function()
+            equipPet:FireServer(petName)
+            refreshInventory()
+        end)
+
+        button.MouseButton2Click:Connect(function()
+            toggleFavorite:FireServer(petName)
+            refreshInventory()
+        end)
+
+        if data.Favorites[petName] then
+            local star = Instance.new("TextLabel")
+            star.Size = UDim2.new(0, 30, 1, 0)
+            star.Position = UDim2.new(1, -35, 0, 0)
+            star.Text = "★"
+            star.TextColor3 = Color3.fromRGB(255, 215, 0)
+            star.BackgroundTransparency = 1
+            star.Parent = button
+        end
+
+        yOffset = yOffset + 35
+    end
+end
+
+refreshInventory()

--- a/RobloxPetExample/README.md
+++ b/RobloxPetExample/README.md
@@ -1,0 +1,30 @@
+# Roblox Pet System Example
+
+This folder contains a simple example of a pet inventory system for Roblox. The code is split into several scripts that should be placed in specific services in your game.
+
+## Files
+
+- **PetDataModule.lua** – stores information about available pets. Place this ModuleScript in `ReplicatedStorage`.
+- **PetInventoryModule.lua** – handles inventory data and saving using DataStore. Place this ModuleScript in `ServerScriptService`.
+- **ServerInit.lua** – creates RemoteEvents and connects them to `PetInventoryModule`. This should be a Script inside `ServerScriptService` next to the inventory module.
+- **PetUIController.lua** – client-side LocalScript that displays the inventory UI and sends requests via RemoteEvents. Place this LocalScript inside `StarterPlayerScripts` or a GUI element.
+
+## Required Objects
+
+1. **Folder `PetEvents`** – created by `ServerInit.lua` under `ReplicatedStorage`. It contains:
+   - `RequestInventory` (`RemoteFunction`)
+   - `EquipPet` (`RemoteEvent`)
+   - `ToggleFavorite` (`RemoteEvent`)
+
+2. **DataStoreService** – used by `PetInventoryModule.lua` to save and load player data. No additional setup is required beyond enabling API access in Roblox Studio settings if you want to test saving locally.
+
+3. **UI** – `PetUIController.lua` dynamically creates a simple inventory window. You can style it further by editing the script or replacing it with your own UI elements.
+
+## How It Works
+
+- When the server starts, `ServerInit.lua` creates the remote events and listens for inventory actions from clients.
+- When a player joins, `PetInventoryModule` loads their saved data (inventory, equipped pet, favorites). When they leave, the data is saved.
+- If a player has no saved data, they begin with three starter pets: **Cat**, **Dog**, and **Fox**.
+- The client requests its inventory via the `RequestInventory` RemoteFunction and renders buttons for each pet. Clicking a pet button equips or unequips it. Right-clicking toggles the favorite status.
+
+This is a minimal setup intended for learning purposes. In a real game you might expand it with animations, more sophisticated data handling and additional gameplay logic.

--- a/RobloxPetExample/ServerInit.lua
+++ b/RobloxPetExample/ServerInit.lua
@@ -1,0 +1,41 @@
+-- ServerInit.lua
+-- Sets up remote events and binds inventory actions
+
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Players = game:GetService("Players")
+
+local PetInventoryModule = require(script.Parent:WaitForChild("PetInventoryModule"))
+
+local eventsFolder = Instance.new("Folder")
+eventsFolder.Name = "PetEvents"
+eventsFolder.Parent = ReplicatedStorage
+
+local requestInventory = Instance.new("RemoteFunction")
+requestInventory.Name = "RequestInventory"
+requestInventory.Parent = eventsFolder
+
+local equipPet = Instance.new("RemoteEvent")
+equipPet.Name = "EquipPet"
+equipPet.Parent = eventsFolder
+
+local toggleFavorite = Instance.new("RemoteEvent")
+toggleFavorite.Name = "ToggleFavorite"
+toggleFavorite.Parent = eventsFolder
+
+requestInventory.OnServerInvoke = function(player)
+    return PetInventoryModule.GetPlayerData(player)
+end
+
+equipPet.OnServerEvent:Connect(function(player, petName)
+    if PetInventoryModule.GetPlayerData(player) then
+        if PetInventoryModule.GetPlayerData(player).EquippedPet == petName then
+            PetInventoryModule.UnequipPet(player)
+        else
+            PetInventoryModule.EquipPet(player, petName)
+        end
+    end
+end)
+
+toggleFavorite.OnServerEvent:Connect(function(player, petName)
+    PetInventoryModule.ToggleFavorite(player, petName)
+end)


### PR DESCRIPTION
## Summary
- give new players three default pets in `PetInventoryModule`
- document starter pets in both READMEs

## Testing
- `luacheck RobloxPetExample/*.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840112e487c83319974e708f85a66b5